### PR TITLE
Read The Docs updates

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,6 +86,15 @@ key = 'READTHEDOCS'
 if key in os.environ and os.environ[key] == 'True':
     print("PRRTE: found ReadTheDocs build environment")
 
+    # Tell Jinja2 templates the build is running on Read the Docs
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
+
+    # Define the canonical URL if you are using a custom domain on
+    # Read the Docs
+    html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
     rtd_v = os.environ['READTHEDOCS_VERSION']
     if os.environ['READTHEDOCS_VERSION_TYPE'] == 'external':
         # Make "release" be shorter than the full "prte_ver" value.


### PR DESCRIPTION
RTD is rolling out some changes. Per
https://about.readthedocs.com/blog/2024/07/addons-by-default/, these are the changes we need to make.

Port of open-mpi/ompi#12687

Signed-off-by: Ralph Castain <rhc@pmix.org>
(from upstream commit 584845fd319f888240a4a2c5570202a1ba2a0c27)