### PR TITLE
Protect against the envar version of the Slurm custom args param

### DIFF
--- a/src/mca/plm/slurm/plm_slurm.h
+++ b/src/mca/plm/slurm/plm_slurm.h
@@ -33,9 +33,8 @@ BEGIN_C_DECLS
 
 struct prte_mca_plm_slurm_component_t {
     prte_plm_base_component_t super;
-    int custom_args_index;
     char *custom_args;
-    bool slurm_warning_msg;
+    bool early;
 };
 typedef struct prte_mca_plm_slurm_component_t prte_mca_plm_slurm_component_t;
 

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -252,6 +252,11 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
     /* add the srun command */
     pmix_argv_append(&argc, &argv, "srun");
+
+    // add the external launcher flag if necessary
+    if (!prte_mca_plm_slurm_component.early) {
+        pmix_argv_append(&argc, &argv, "--external-launcher");
+    }
 
     /* start one orted on each node */
     pmix_argv_append(&argc, &argv, "--ntasks-per-node=1");

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -179,6 +179,24 @@ int prte_init_minimum(void)
         return PRTE_ERR_SILENT;
     }
 
+    /* Protect against the envar version of the Slurm
+     * custom args MCA param. This is an unfortunate
+     * hack that hopefully will eventually go away.
+     * See both of the following for detailed
+     * explanations and discussion:
+     *
+     * https://github.com/openpmix/prrte/issues/1974
+     * https://github.com/open-mpi/ompi/issues/12471
+     *
+     * Orgs/users wanting to add custom args to the
+     * internal "srun" command used to spawn the
+     * PRRTE daemons must do so via the default MCA
+     * param files (system or user), or via the
+     * prterun (or its proxy) cmd line
+     */
+    unsetenv("PRTE_MCA_plm_slurm_args");
+    unsetenv("OMPI_MCA_plm_slurm_args");
+
     /* carry across the toolname */
     pmix_tool_basename = prte_tool_basename;
 


### PR DESCRIPTION
Protect against the envar version of the Slurm
custom args MCA param. This is an unfortunate
hack that hopefully will eventually go away.
See both of the following for detailed
explanations and discussion:

https://github.com/openpmix/prrte/issues/1974
https://github.com/open-mpi/ompi/issues/12471

Orgs/users wanting to add custom args to the
internal "srun" command used to spawn the
PRRTE daemons must do so via the default MCA
param files (system or user), or via the
prterun (or its proxy) cmd line

Signed-off-by: Ralph Castain <rhc@pmix.org>
(from upstream commit 28432ed70f1dec5be4889af39f1a5c4947b9fc32)