### PR TITLE
make distcheck fixes

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -10,7 +10,7 @@
 #
 
 include_HEADERS = \
-        prte.h
+        prte.h \
+        prte_version.h
 
-nodist_include_HEADERS = \
-    prte_version.h
+nodist_include_HEADERS :=

--- a/src/docs/prrte-rst-content/Makefile.am
+++ b/src/docs/prrte-rst-content/Makefile.am
@@ -44,6 +44,7 @@ dist_rst_DATA = \
     cli-prefix.rst \
     cli-prepend-env.rst \
     cli-prtemca.rst \
+    cli-no-app-prefix.rst \
     cli-rank-by.rst \
     cli-runtime-options.rst \
     cli-stream-buffering.rst \


### PR DESCRIPTION
prte_version.h needs to be added to dist tarball.
fix a problem with document generation.