### PR TITLE
GH: fork_sync

### DIFF
--- a/.github/workflows/fork_sync.yaml
+++ b/.github/workflows/fork_sync.yaml
@@ -13,11 +13,12 @@ jobs:
     steps:
       - uses: tgymnich/fork-sync@v1.8
         with:
-          token: ${{ secrets.PRRTE_SYNC_UPSTREAM_MASTER_ID }}
           owner: openpmix
+          token: ${{ secrets.GITHUB_TOKEN }}
           base: master
           head: master
           auto_merge: true
           auto_approve: false
+          ignore_fail: true
 
           


### PR DESCRIPTION
switch to using default github action credentials