### PR TITLE
add fork sync gha to ompi_main branch

### DIFF
--- a/.github/workflows/fork_sync.yaml
+++ b/.github/workflows/fork_sync.yaml
@@ -1,0 +1,24 @@
+name: Sync Fork
+
+on:
+  schedule:
+    - cron: '* 13 * * *' # every day at 13 hours
+  workflow_dispatch: # on button click
+
+jobs:
+  sync:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: tgymnich/fork-sync@v1.8
+        with:
+          owner: openpmix
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: master
+          head: master
+          auto_merge: false
+          auto_approve: false
+          ignore_fail: true
+
+          


### PR DESCRIPTION
it seems that without having this action on ompi_main, its difficult to trigger manually.

Note the action still targets just keeping the 'master' branch in sync with upstream prrte master.